### PR TITLE
Fixed reading data getting truncated using a 40x40 video hub

### DIFF
--- a/videohubctrl.c
+++ b/videohubctrl.c
@@ -416,7 +416,7 @@ static int read_device_command_stream(struct videohub_data *d) {
 	if (test_data)
 		return 0;
 	memset(buf, 0, sizeof(buf));
-	while ((ret = fdread_ex(d->dev_fd, buf, sizeof(buf) - 1, 5, 0, 0)) >= 0) {
+	while ((ret = fdread_ex(d->dev_fd, buf, sizeof(buf) - 1, 5, 0, 1)) >= 0) {
 		ncommands += parse_text_buffer(d, buf);
 		memset(buf, 0, sizeof(buf));
 	}


### PR DESCRIPTION
The data read from the 40x40 videohub got truncated. This caused the tool not to work properly cause some input- and output labels went missing.

Adding this option got things to work again.

With a 12x12 things worked fine.