### PR TITLE
Handle larger responses from Universal Videohub 288

### DIFF
--- a/videohubctrl.c
+++ b/videohubctrl.c
@@ -420,7 +420,11 @@ static void print_device_full(struct videohub_data *d) {
 
 static int read_device_command_stream(struct videohub_data *d) {
 	int ret, ncommands = 0;
-	char buf[8192 + 1];
+        /* On a Universal Videohub 288 you can get 3231 lines of output,
+         * let's assume worst case of 80 characters per line, so a 300KB
+         * message.
+         */
+        char buf[300 * 1024 + 1];
 	if (test_data)
 		return 0;
 	memset(buf, 0, sizeof(buf));


### PR DESCRIPTION
The Universal Videohub 288 will generate much larger responses than can fit a 8KB buffer. Since parsing expects to handle a complete message from the router, increase the maximum buffer / response size to handle 3,200+ line response.

With this change I was able to correctly read and parse the status from a Universal Videohub 288.

Signed-off-by: Jean-Francois Panisset <panisset@gmail.com>